### PR TITLE
Fix binding issue

### DIFF
--- a/src/main/resources/js/main.js
+++ b/src/main/resources/js/main.js
@@ -41,7 +41,8 @@ const FullPage = React.createClass({
           <ContractBox
             contractEntry={this.state.contractMap.get(this.state.contractId)}
             handleUpdate={/*this.handleContractBoxUpdate*/
-                          this.state.contractStorageHandler.setContractEntry}
+                          this.state.contractStorageHandler.setContractEntry
+                            .bind(this.state.contractStorageHandler)}
             logins={this.state.logins}
             pollInterval={2000}
           />;


### PR DESCRIPTION
When you updated a field, nothing happened in the
ContractStorageHandler.setContractEntry because this was set to
ContractBox.props instead of ContractStorageHandler

Closes #30.
